### PR TITLE
Enable changing of the NR endpoint through the config

### DIFF
--- a/src/jnpr_nr_plugin/nr/nrproxy.py
+++ b/src/jnpr_nr_plugin/nr/nrproxy.py
@@ -15,7 +15,8 @@ LOGGER = logging.getLogger(__name__)
 class NRProxy(listeners.Listener):
     def __init__(self, config):
         self.config = config
-        self.URL = 'https://platform-api.newrelic.com/platform/v1/metrics'
+        self.ENDPOINT = self.config.get('endpoint', 'https://platform-api.newrelic.com')
+        self.URL = self.ENDPOINT + '/platform/v1/metrics'
         self.MAX_STATS_PER_POST = self.config.get('max_stats', 8000)
         self.NAME = self.config.get('name', 'net.juniper.jnpr_nr_plugin')
         self.UID = self.NAME + '.Juniper'


### PR DESCRIPTION
The configuration for the New Relic endpoint is hard-coded into the nrproxy module.  This change would allow a user to change that endpoint through the YAML configuration.
